### PR TITLE
Repaired previously-made changes lost during recent merge

### DIFF
--- a/data_warehouse_client/data_warehouse.py
+++ b/data_warehouse_client/data_warehouse.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from datetime import datetime
-from sys import exit
 import psycopg2
 from json import load
 from more_itertools import intersperse
@@ -172,32 +171,36 @@ class DataWarehouse:
         self.credentialsFile = credentials_file
         self.dbName = db_name
         # load credentials
-        print("Loading credentials..")
         try:
             with open(self.credentialsFile, 'r') as fIn:
                 creds = load(fIn)
         except Exception as e:
-            exit("Unable to load the credential's file! Exiting.\n" + str(e))
+            print(f"Unable to load credentials from: {self.credentialsFile}")
+            raise
+        print("Credentials file loaded")
 
-        print("Connecting to the database..")
         # establish connection
         conn_string = f"dbname={self.dbName} user={creds['user']} host={creds['IP']} password={creds['pass']}"
         try:
             self.dbConnection = psycopg2.connect(conn_string)
         except Exception as e:
-            exit("Unable to connect to the database! Exiting.\n" + str(e))
-        print("Init successful! Running queries.\n")
+            print(f"Unable to connect to the database with connection string:\n"+
+                  f"\tdbname={self.dbName} user={creds['user']} host={creds['IP']} password=****************")
+            raise
+        print(f"Connected to database {self.dbName} as user {creds['user']}")
 
 
     ###########################################################################
     # General SQL methods
     ###########################################################################
-    def return_query_result(self, query_text):
+    def return_query_result(self: object, query_text: str) -> list:
         """
-        executes an SQL query. It is used for SELECT queries.
-        :param query_text: the SQL
-        :return: the result as a list of rows.
+        Executes an SQL query. It is used for SELECT queries.
+        :param query_text: The SQL query text.
+        :return: The result as a list of rows. If there are no matches an
+        empty list is returned.
         """
+        # TODO: verify best practice exception handling and rollback
         cur = self.dbConnection.cursor()
         try:
             cur.execute(query_text)
@@ -209,12 +212,14 @@ class DataWarehouse:
             raise
 
 
-    def exec_insert_with_return(self, query_text):
+    # TODO: This function is never used, and it should be!
+    def exec_insert_with_return(self: object, query_text: str) -> list:
         """
         Executes INSERT, commits the outcome and returns the result from the RETURNING clause.
         :param query_text: the SQL
         :return the result from the RETURNING clause
         """
+        # TODO: verify best practice exception handling and rollback
         cur = self.dbConnection.cursor()
         try:
             cur.execute(query_text)
@@ -226,11 +231,12 @@ class DataWarehouse:
             raise
 
 
-    def exec_sql_with_no_return(self, query_text):
+    def exec_sql_with_no_return(self: object, query_text: str) -> list:
         """
         executes SQL and commits the outcome. Used to execute INSERT, UPDATE and DELETE statements with no RETURNING.
         :param query_text: the SQL
         """
+        # TODO: verify best practice exception handling and rollback
         cur = self.dbConnection.cursor()
         try:
             cur.execute(query_text)
@@ -446,6 +452,7 @@ class DataWarehouse:
             return False
 
 
+    # TODO: return better values from this function (bool, id)
     def add_measurement_type(self, study: int, valtype: int, description: str, unit=None) -> int:
         """
         Adds a new measurementtype. A combination of the descriptive names and
@@ -477,20 +484,18 @@ class DataWarehouse:
             return False, res[0][0]
         
         # Add the new measurementtype
-        q = " SELECT MAX(id) FROM measurementtype; "
-        res = self.return_query_result(q)  # find the biggest id
-        max_id = res[0][0]
-        if max_id is None:
-            free_id = 0
-        else:
-            free_id = max_id + 1  # the next free id
-        cur.execute("""
-                    INSERT INTO measurementtype (id, description, valtype, units, study)
-                    VALUES (%s, %s, %s, %s, %s);
-                    """,
-                    (free_id, description, valtype, unit, study))  # insert the new entry
-        self.dbConnection.commit()
-        return True, free_id
+        try:
+            cur.execute("""
+                        INSERT INTO measurementtype (id, description, valtype, units, study)
+                        VALUES (DEFAULT, %s, %s, %s, %s);
+                        """,
+                        (description, valtype, unit, study))  # insert the new entry
+            self.dbConnection.commit()
+        except Exception as e:
+            print(f"Error: {e}")
+            self.dbConnection.rollback()
+            raise
+        return True, None
 
     
     ###########################################################################
@@ -903,7 +908,7 @@ class DataWarehouse:
         return len(res)>0
 
 
-    def add_sourcetype(self, study: int, description: str, version=None) -> tuple:
+    def insert_sourcetype(self, study: int, description: str, version=None) -> tuple:
         """
         Adds a sourcetype
         :param study: the study that the sourcetype is attached to
@@ -919,20 +924,19 @@ class DataWarehouse:
         res = self.return_query_result(q)  # find the biggest id
         max_id = res[0][0]
         if max_id is None:
-            free_id = 0
+            free_id = 1
         else:
             free_id = max_id + 1  # the next free id
         cur.execute("""
                     INSERT INTO sourcetype (id, study, description, version)
-                    VALUES (%s, %s, %s, %s);
+                    VALUES (DEFAULT, %s, %s, %s);
                     """,
-                    (free_id,
-                     study,
+                    (study,
                      description,
                      ("NULL" if not version else version)))  # insert the new entry
         self.dbConnection.commit()
-        return free_id
-    
+        return True, free_id
+
 
     def update_sourcetype_version(self, id: int, version: str) -> tuple:
         """
@@ -954,7 +958,7 @@ class DataWarehouse:
         return id
 
 
-    def get_source_by_description(self, description: str, sourcetype) -> tuple:
+    def get_source_by_description(self: object, sourcetype: int, sourceid: str) -> tuple:
         """
         Gets a source entry corresponding to a description of a source
         :param sourcetype: the sourcetype id that the source is an instance of
@@ -964,16 +968,16 @@ class DataWarehouse:
         """
         q = """
             SELECT id FROM source
-            WHERE source.sourceid='{}' and source.sourcetype='{}';
-            """.format(description, sourcetype)
+            WHERE source.sourcetype='{}' and source.sourceid='{}';
+            """.format(sourcetype, sourceid)
         res = self.return_query_result(q)
         if len(res) > 0:
             return True, res[0][0]
         else:
             return False, res
-        
 
-    def add_source(self, sourcetype: int, sourceid: str) -> tuple:
+    
+    def insert_source(self: object, sourcetype: int, sourceid: str) -> tuple:
         """
         Adds a source. This doesn't check for duplicate names.
         :param sourcetype: the sourcetype id that the source is an instance of
@@ -987,43 +991,37 @@ class DataWarehouse:
             """.format(sourcetype)
         res = self.return_query_result(q)
         study = res[0][0]
-        if study is None:
-            return None
-        
-        # Get next free ID
-        q = """
-            SELECT MAX(id) FROM source;
-            """
-        res = self.return_query_result(q)
-        max_id = res[0][0]
-        if max_id is None:
-            free_id = 0
-        else:
-            free_id = max_id + 1  # the next free id
+        if study == []:
+            return False, None
         
         # Insert new entry
+        # TODO: this should use a standard function with exception handling
+        # TODO: using cur.mogrify to produce the string
         cur = self.dbConnection.cursor()
-        cur.execute("""
-                    INSERT INTO source (id, sourceid, sourcetype, study)
-                    VALUES (%s, %s, %s, %s);
-                    """,
-                    (free_id,
-                     sourceid,
-                     sourcetype,
-                     study))
-        self.dbConnection.commit()
-        return free_id
-    
+        try:
+            cur.execute("""
+                        INSERT INTO source (id, sourceid, sourcetype, study)
+                        VALUES (DEFAULT, %s, %s, %s);
+                        """,
+                        (sourceid, sourcetype, study))
+            self.dbConnection.commit()
+        except Exception as e:
+            print(f"Error {e}")
+            self.dbConnection.rollback()
+            raise
+
+        return self.get_source_by_description(sourcetype, sourceid)
+
 
     ###########################################################################
     # Participant methods
     ###########################################################################
-    def get_participant_by_id(self, study, participant):
+    def get_participant_by_id(self: object, study: int, participant: int):
         """
-         maps from unique participant.id to the local id stored with measurements in the warehouse
+        maps from unique participant.id to the local id stored with measurements in the warehouse
          :param study: the study id
-         :param participant: the id of the participant in the study
-         :return The participantid of the participant
+         :param participant: the participant id in the study
+         :return The participantid (name)
          """
         q = " SELECT participantid FROM participant " \
             " WHERE participant.study       = " + str(study) + \
@@ -1034,18 +1032,18 @@ class DataWarehouse:
             return found, res[0][0]
         else:
             # print("Participant", participant, " not found in participant.id")
-            return found, res
+            return found, None
 
 
-    def get_participant(self, study_id, local_participant_id):
+    def get_participant(self: object, study: int, local_participant_id: str) -> tuple:
         """
-        maps from a participantid that is local to the study, to the unique id stored with measurements in the warehouse
+        Returns the unique id of a participant referenced by its local
         :param study_id: the study id
         :param local_participant_id: the local participant id in the study
         :return The id of the participant
         """
         q = " SELECT id FROM participant " \
-            " WHERE participant.study       = " + str(study_id) + \
+            " WHERE participant.study       = " + str(study) + \
             " AND participant.participantid = '" + local_participant_id + "';"
         res = self.return_query_result(q)
         found = len(res) == 1
@@ -1056,7 +1054,7 @@ class DataWarehouse:
             return found, res
 
 
-    def get_participants(self, study_id):
+    def get_participants(self: object, study_id: int) -> list:
         """
         Get all participants in a study
         :param study_id: the study id
@@ -1068,32 +1066,28 @@ class DataWarehouse:
         return res
 
 
-    def add_participant(self, study_id, local_participant_id):
+    def insert_participant(self: object, study_id: int, local_participant_id: str) -> tuple:
         """
         add a participant into the data warehouse
         :param study_id: the study id
         :param local_participant_id: the local name for the participant
-        :res the new participant id
+        :return the new participant id
         """
         cur = self.dbConnection.cursor()
-        q = " SELECT MAX(id) FROM participant " \
-            " WHERE participant.study = " + str(study_id) + ";"
-        res = self.return_query_result(q)  # find the biggest id
-        max_id = res[0][0]
-        if max_id is None:
-            free_id = 0
-        else:
-            free_id = max_id + 1  # the next free id
         cur.execute("""
                     INSERT INTO participant(id,participantid,study)
-                    VALUES (%s, %s, %s);
+                    VALUES (DEFAULT, %s, %s);
                     """,
-                    (free_id, local_participant_id, study_id))  # insert the new entry
+                    (local_participant_id, study_id))  # insert the new entry
         self.dbConnection.commit()
-        return free_id
+        return self.get_participant(study_id, local_participant_id)
 
 
-    def add_participant_if_new(self, study_id, participant_id, local_participant_id):
+    ###########################################################################
+    # WARNING: This function doesn't look like it works properly, consider
+    # removal / updating. Have disabled it for now as it looks like it could
+    # corrupt indexes
+    def add_participant_if_new(self: object, study: int, participant_id: int, local_participant_id: str):
         """
         add a participant into the data warehouse unless they already exist
         :param study_id: the study id
@@ -1101,10 +1095,12 @@ class DataWarehouse:
         :param local_participant_id: the local name for the participant
         :res (participant_added, new participant id)
         """
+        print("Function 'add_participant_if_new()' is disabled")
+        return
         cur = self.dbConnection.cursor()
 
         q = " SELECT id, participantid FROM participant " \
-            " WHERE participant.study = " + str(study_id) + \
+            " WHERE participant.study = " + str(study) + \
             " AND participant.id =  " + str(participant_id) + ";"
         res = self.return_query_result(q)
         participant_already_exists = len(res) > 0
@@ -1115,7 +1111,7 @@ class DataWarehouse:
                         INSERT INTO participant(id,participantid,study)
                         VALUES (%s, %s, %s);
                         """,
-                        (participant_id, local_participant_id, study_id))  # insert the new entry
+                        (participant_id, local_participant_id, study))  # insert the new entry
             self.dbConnection.commit()
             return True, participant_id
 
@@ -1123,7 +1119,7 @@ class DataWarehouse:
     ###########################################################################
     # Study methods
     ###########################################################################
-    def studyp(self, id: int) -> bool:
+    def studyp(self: object, id: int) -> bool:
         """
         Study existence predicate
         :param: study id
@@ -1227,7 +1223,7 @@ class DataWarehouse:
         return res
 
 
-    def add_trial(self, study: int, trial_description: str) -> int:
+    def insert_trial(self: object, study: int, trial_description: str) -> int:
         """
         Add a trial into the data warehouse, for a particular study
         :param study: the study id to attach the trial to
@@ -1235,21 +1231,28 @@ class DataWarehouse:
         :return the database id of the new trial
         """
         cur = self.dbConnection.cursor()
-        q = " SELECT MAX(id) FROM trial; "
-        res = self.return_query_result(q)  # find the biggest id
+        q = cur.mogrify("SELECT MAX(id) FROM trial WHERE study = %s;", (study,))
+        res = self.return_query_result(q)  # Find the biggest id in the study
         max_id = res[0][0]
         if max_id is None:
-            free_id = 0
+            free_id = 1
         else:
             free_id = max_id + 1  # the next free id
-        cur.execute("""
-                    INSERT INTO trial (id, study, description)
-                    VALUES (%s, %s, %s);
-                    """,
-                    (free_id, study, trial_description))  # insert the new entry
-        self.dbConnection.commit()
-        return free_id
-    
+        # TODO: call the correct function which has exception and rollback handling
+        try:
+
+            cur.execute("""
+                        INSERT INTO trial (id, study, description)
+                        VALUES (%s, %s, %s);
+                        """,
+                        (free_id, study, trial_description))  # insert the new entry
+            self.dbConnection.commit()
+        except Exception as e:
+            print(f"Error {e}")
+            self.dbConnection.rollback()
+            raise
+        return True, free_id
+
 
     def add_trial_if_unique(self, study: int, trial_description: str) -> tuple:
         """
@@ -1515,3 +1518,4 @@ class DataWarehouse:
                     (measurementtype, minval, maxval, study))
         self.dbConnection.commit()
         return True
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,10 @@ dependencies = [
     "psycopg2",
     "tabulate",
     "pandas",
-    "ydata-profiling"
+    "ydata-profiling",
+    "unidecode"
 ]
-requires-python = ">= 3.12"
+requires-python = ">=3.12,<3.14"
 authors = [
     {name = "Paul Watson", email = "paul.watson@newcastle.ac.uk"},
 ]


### PR DESCRIPTION
Recent merge `dev` -> `master` (6578c08370f9a2a32151669ddee8d15aaf1cd4d1) lost changes in `data_warehouse.py` specifically in: `DataWarehouse` class constructor; `return_query_result()`; `exec_insert_with_return()`; `exec_sql_with_no_return()`; `insert_sourcetype()`; `get_source_by_description()`; `insert_source()`; `get_participant_by_id()`; `get_participants()`; `insert_participant()`; `add_participant_if_new()`; `studyp()`; `insert_trial()`

The changes to these functions were
- to correctly handle transaction failures and properly rollback the database cursor state to prevent the DB connection being left in an error state
- to standardise some function naming conventions and correct some docstrings
- to use `DEFAULT` in SQL `INSERT` statements so that sequences are used correctly
- to standardise return value forms across similar functions

Additionally a small change to `pyproject.toml` more closely defines the Python version to ensure `ydata-profiling` compatibility and adds `unidecode` as a dependency.